### PR TITLE
Do not clear timeout if proc's exitCode is null

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -313,7 +313,7 @@ module.exports = function (proto) {
 
     function cb (err, stdout, stderr, cmd) {
       if (cb.called) return;
-      if (timeoutId) clearTimeout(timeoutId);
+      if (timeoutId && proc.exitCode) clearTimeout(timeoutId);
       cb.called = 1;
       if (args[0] !== 'identify' && bin !== 'identify') {
 	self._in = [];


### PR DESCRIPTION
I have ImageMagick 6.9.9-9 installed locally. In some case I found that the spawned child process for calling ImageMagick hangs forever and thus calling gm.toBuffer never return, I know this is an issue from ImageMagick lib(for example : [imagemagicks-convert-hangs](https://stackoverflow.com/questions/42874153/imagemagicks-convert-hangs)) but in this case I expect the gm library to kill the spawned process when the timeout option is given. I found that the timer in the **cb** function get cleared regardless of the exit code from the spawned process. This fix adds check to make sure the timer only get cleared if there is a valid exit code from the spawned process, otherwise the timeout function should be trigged to kill the spawned process after the timeout value elapses.